### PR TITLE
fix: Error: companyName is a required option to crashReporter.start

### DIFF
--- a/exercises/hello_electron/problem.ja.md
+++ b/exercises/hello_electron/problem.ja.md
@@ -22,7 +22,10 @@ const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
 
 // Report crashes to our server.
-electron.crashReporter.start();
+electron.crashReporter.start(
+  'companyName': '',
+  'submitURL': ''
+);
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.

--- a/exercises/hello_electron/problem.md
+++ b/exercises/hello_electron/problem.md
@@ -22,7 +22,10 @@ const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
 
 // Report crashes to our server.
-electron.crashReporter.start();
+electron.crashReporter.start({
+  'companyName': '',
+  'submitURL': ''
+});
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.


### PR DESCRIPTION
Copying the js code as is produces the below error.

```
App threw an error during load
Error: companyName is a required option to crashReporter.start
    at CrashReporter.start (/Users/ST47/projects/others/electronica_test/node_modules/electron-prebuilt/dist/Electron.app/Contents/Resources/electron.asar/common/api/crash-reporter.js:37:13)
    at Object.<anonymous> (/Users/ST47/projects/others/electronica_test/index.js:7:24)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at loadApplicationPackage (/Users/ST47/projects/others/electronica_test/node_modules/electron-prebuilt/dist/Electron.app/Contents/Resources/default_app.asar/main.js:288:12)
    at Object.<anonymous> (/Users/ST47/projects/others/electronica_test/node_modules/electron-prebuilt/dist/Electron.app/Contents/Resources/default_app.asar/main.js:330:5)
    at Module._compile (module.js:556:32)
```

It seems like `companyName` and `submitURL` are required so I've added those two properties.
This is just a temporary measure to ensure that #nodefest can continue smoothly. It might help to amend the instructions when the event is over.

https://github.com/electron/electron/blob/master/docs/api/crash-reporter.md#crashreporterstartoptions